### PR TITLE
Change model orientation so it matches the sample screenshots

### DIFF
--- a/engines.json
+++ b/engines.json
@@ -1,11 +1,11 @@
 {
     "BabylonJS": {
-        "templateUrl": "https://sandbox.babylonjs.com/index.html?assetUrl=${assetUrl}&cameraPosition=${-cameraPosition.x},${cameraPosition.y},${cameraPosition.z}&kiosk=true"
+        "templateUrl": "https://sandbox.babylonjs.com/index.html?assetUrl=${assetUrl}&cameraPosition=${cameraPosition.x},${cameraPosition.y},${cameraPosition.z}&kiosk=true"
     },
     "PlayCanvas": {
         "templateUrl": "https://playcanvas.github.io/playcanvas-gltf/viewer/index.html?assetUrl=${assetUrl}&cameraPosition=${-cameraPosition.x},${cameraPosition.y},${cameraPosition.z}"
     },
     "ThreeJS": {
-        "templateUrl": "https://gltf-viewer.donmccurdy.com/#model=${assetUrl}&cameraPosition=${cameraPosition.x},${cameraPosition.y},${cameraPosition.z}&kiosk=true&preset=assetgenerator"
+        "templateUrl": "https://gltf-viewer.donmccurdy.com/#model=${assetUrl}&cameraPosition=${-cameraPosition.x},${cameraPosition.y},${cameraPosition.z}&kiosk=true&preset=assetgenerator"
     }
 }


### PR DESCRIPTION
Change to how the X value for the camera position is handled in the template strings. BabylonJS and ThreeJS use different coordinate systems, so inverting the X value is needed for one of them. 

Because the screenshot generator uses BabylonJS but was not inverting the X position of the camera, the sample images didn't match the viewer versions of the same models. This corrects that discrepancy.

fixes  https://github.com/KhronosGroup/glTF-Asset-Generator/issues/522