### PR TITLE
Update to newly released PlayCanvas glTF viewer

### DIFF
--- a/engines.json
+++ b/engines.json
@@ -3,7 +3,7 @@
         "templateUrl": "https://sandbox.babylonjs.com/index.html?assetUrl=${assetUrl}&cameraPosition=${-cameraPosition.x},${cameraPosition.y},${cameraPosition.z}&kiosk=true"
     },
     "PlayCanvas": {
-        "templateUrl": "https://playcanvas.github.io/playcanvas-gltf/viewer/index.html?assetUrl=${assetUrl}&cameraPosition=${-cameraPosition.x},${cameraPosition.y},${cameraPosition.z}"
+        "templateUrl": "https://playcanvas.com/viewer/?assetUrl=${assetUrl}&cameraPosition=${-cameraPosition.x},${cameraPosition.y},${cameraPosition.z}"
     },
     "ThreeJS": {
         "templateUrl": "https://gltf-viewer.donmccurdy.com/#model=${assetUrl}&cameraPosition=${cameraPosition.x},${cameraPosition.y},${cameraPosition.z}&kiosk=true&preset=assetgenerator"


### PR DESCRIPTION
A brand new PlayCanvas glTF 2.0 viewer has been published. This PR updates the viewer URL.

Fixes https://github.com/playcanvas/playcanvas-viewer/issues/33
